### PR TITLE
Include *.Core classes/enumerations in the stubs for e.g. *.Esp32

### DIFF
--- a/Nuspec and stub-generation.md
+++ b/Nuspec and stub-generation.md
@@ -1,0 +1,20 @@
+﻿# Nuspec / NuGet packages
+
+The `nanoFramework.Device.Can` namespace implements the classical CAN (2.0, ISO 11898) protocol. As the CAN protocol only covers the physical and data link layers of the OSI model, additional protocols (e.g., CAN-TP) are required to cover the other layers. The code for those protocols can be based on the device independent class library `nanoFramework.Device.Can.Core` and debugged/tested on any device, including the Virtual nanoDevice. For an application one of the device dependent class libraries like `nanoFramework.Device.Can.Stm32` should be added to connect to a device that is connected to the CAN bus.
+
+Hence the NuGet package for a device dependent class library should include only the assemblies for that library and not the `nanoFramework.Device.Can.Core` files. It should have the `nanoFramework.Device.Can.Core` NuGet package as dependency, with the same version as the device dependent NuGet package (`$version$`). The project for a device dependent class library does not reference the `nanoFramework.Device.Can.Core` NuGet package but references the `nanoFramework.Device.Can.Core.nfproj` instead. 
+
+# Stub generation
+
+If a device dependent class library requires part of its implementation to be a native component, it should be configured to generate stubs for the native code. It is very likely that the native code also requires information about classes and enumerations that are part of the `nanoFramework.Device.Can.Core` class library. As that is a pure .NET library, there is (at the time of writing) no way to generate header files from `nanoFramework.Device.Can.Core`.
+
+As a workaround, the `nanoFramework.Device.Can.sln` solution has an extra configuration **GenerateStubs** in addition to *Debug* and *Release*. Select that configuration to generate the stubs. The stubs are placed in, e.g., the `nanoFramework.Device.Can.Esp32\bin\GenerateStubs\Stubs` directory. The stubs in other directories, e.g., `nanoFramework.Device.Can.Esp32\bin\Debug\Stubs`, are not complete.
+
+The *nfproj* project for the device dependent class library has to be prepared for that (see *nanoFramework.Device.Can.Esp32.nfproj* as example):
+
+- Remove the direct reference to `nanoFramework.Device.Can.Core` from the class library's project.
+- Create a copy of `nanoFramework.Device.Can.Esp32.native.props` as, e.g., `nanoFramework.Device.Can.MyDevice.native.props` in the class library's project directory.
+- Modify the *nfproj* file and add `<Import Project="nanoFramework.Device.Can.MyDevice.native.props" />` just before the first `<PropertyGroup>`
+- Change the `NF_GenerateSkeletonProjectName` and `Name` in `nanoFramework.Device.Can.MyDevice.native.props`.
+- Ensure the relevant code files from `nanoFramework.Device.Can.Core` are listed in `nanoFramework.Device.Can.MyDevice.native.props`.
+- Open the `nanoFramework.Device.Can.sln` solution file in Visual Studio, Open the `Configuration Manager` for the solution, select `GenerateStubs` and select for the class library configuration `GenerateStubs` and check that the project is built for this configuration.

--- a/Stub-generation.md
+++ b/Stub-generation.md
@@ -1,5 +1,0 @@
-﻿# Stub generation
-
-The libraries that require a native components generate a stub for the native part on each build. The stub is placed in, e.g., the `nanoFramework.Device.Can.Stm32\bin\Release\Stubs` directory.
-
-The native component will probably require access to the common classes in `nanoFramework.Device.Can.Core`. As that library is pure .NET, no stub is required. To generate the stub, select the **GenerateStub** configuration (instead of *Debug* or *Release*) in the *nanoFramework.Device.Can.sln* solution and build the solution. The stub will be placed in the `nanoFramework.Device.Can.Core\bin'\GenerateStubs\Stubs` directory.

--- a/nanoFramework.Device.Can.Core/CanController.cs
+++ b/nanoFramework.Device.Can.Core/CanController.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) .NET Foundation and Contributors
-// See LICENSE file in the project root for full license information.
-//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Runtime.CompilerServices;
@@ -67,10 +65,11 @@ namespace nanoFramework.Device.Can
                 // call native init to allow HAL/PAL inits related with Can hardware
                 NativeInit();
 
+#if !GENERATESTUBS
                 // add controller to collection, with the ID as key 
                 // ** just the index number ***
                 CanControllerManager.ControllersCollection.Add(this);
-
+#endif
                 // add the controller to the event listener in order to receive the callbacks from the native interrupts
                 s_eventListener.AddCanController(this);
             }
@@ -102,6 +101,7 @@ namespace nanoFramework.Device.Can
 
         internal static CanController FindController(int index)
         {
+#if !GENERATESTUBS
             for (int i = 0; i < CanControllerManager.ControllersCollection.Count; i++)
             {
                 if (((CanController)CanControllerManager.ControllersCollection[i])._controllerId == index)
@@ -109,7 +109,7 @@ namespace nanoFramework.Device.Can
                     return (CanController)CanControllerManager.ControllersCollection[i];
                 }
             }
-
+#endif
             return null;
         }
 
@@ -121,9 +121,10 @@ namespace nanoFramework.Device.Can
             {
                 if (disposing)
                 {
+#if !GENERATESTUBS
                     // remove controller from controller collection
                     CanControllerManager.ControllersCollection.Remove(this);
-
+#endif
                     // remove the controller from the event listener
                     s_eventListener.RemoveCanController(_controllerId);
                 }

--- a/nanoFramework.Device.Can.Core/nanoFramework.Device.Can.Core.nfproj
+++ b/nanoFramework.Device.Can.Core/nanoFramework.Device.Can.Core.nfproj
@@ -1,24 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Nerdbank.GitVersioning.3.7.115\build\Nerdbank.GitVersioning.props" Condition="Exists('..\packages\Nerdbank.GitVersioning.3.7.115\build\Nerdbank.GitVersioning.props')" />
-  <ItemGroup Label="ProjectConfigurations">
-    <ProjectConfiguration Include="Debug|AnyCPU">
-      <Configuration>Debug</Configuration>
-      <Platform>AnyCPU</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="GenerateStubs|AnyCPU">
-      <Configuration>GenerateStubs</Configuration>
-      <Platform>AnyCPU</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|AnyCPU">
-      <Configuration>Release</Configuration>
-      <Platform>AnyCPU</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="StubGeneration|AnyCPU">
-      <Configuration>StubGeneration</Configuration>
-      <Platform>AnyCPU</Platform>
-    </ProjectConfiguration>
-  </ItemGroup>
   <PropertyGroup Label="Globals">
     <NanoFrameworkProjectSystemPath>$(MSBuildExtensionsPath)\nanoFramework\v1.0\</NanoFrameworkProjectSystemPath>
   </PropertyGroup>
@@ -48,20 +30,6 @@
   <PropertyGroup>
     <DelaySign>false</DelaySign>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)' == 'GenerateStubs' ">
-    <NF_IsCoreLibrary>True</NF_IsCoreLibrary>
-    <DefineConstants>$(DefineConstants);STUBGENERATION</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Label="nanoFramework" Condition=" '$(Configuration)' == 'GenerateStubs' ">
-    <NF_GenerateStubsDirectory>bin\$(Configuration)\Stubs</NF_GenerateStubsDirectory>
-    <NF_GenerateSkeletonProjectName>nf_device_can_core_native</NF_GenerateSkeletonProjectName>
-    <Name>nanoFramework.Device.Can.Core</Name>
-  </PropertyGroup>
-  <ItemGroup>
-    <NFMDP_PE_ExcludeClassByName Include="ThisAssembly">
-      <InProject>false</InProject>
-    </NFMDP_PE_ExcludeClassByName>
-  </ItemGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
     <Compile Include="CanController.cs" />

--- a/nanoFramework.Device.Can.Esp32.nuspec
+++ b/nanoFramework.Device.Can.Esp32.nuspec
@@ -21,6 +21,7 @@ This package requires a target with nanoFramework.Device.Can.Esp32 v$nativeVersi
     <tags>nanoFramework C# csharp netmf netnf canbus can</tags>
     <dependencies>
       <dependency id="nanoFramework.CoreLibrary" version="1.16.11" />
+      <dependency id="nanoFramework.Runtime.Events" version="1.11.29" />
       <dependency id="nanoFramework.Device.Can.Core" version="$version$" />
     </dependencies>
   </metadata>

--- a/nanoFramework.Device.Can.Esp32/nanoFramework.Device.Can.Esp32.native.props
+++ b/nanoFramework.Device.Can.Esp32/nanoFramework.Device.Can.Esp32.native.props
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|AnyCPU">
+      <Configuration>Debug</Configuration>
+      <Platform>AnyCPU</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="GenerateStubs|AnyCPU">
+      <Configuration>GenerateStubs</Configuration>
+      <Platform>AnyCPU</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|AnyCPU">
+      <Configuration>Release</Configuration>
+      <Platform>AnyCPU</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup>
+    <NF_IsCoreLibrary>True</NF_IsCoreLibrary>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'GenerateStubs' ">
+    <DefineConstants>$(DefineConstants);GENERATESTUBS</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Label="nanoFramework">
+    <NF_GenerateStubsDirectory>bin\$(Configuration)\Stubs</NF_GenerateStubsDirectory>
+    <NF_GenerateSkeletonProjectName>nf_device_can_esp32_native</NF_GenerateSkeletonProjectName>
+    <Name>nanoFramework.Device.Can.Esp32</Name>
+  </PropertyGroup>
+  <ItemGroup>
+    <NFMDP_PE_ExcludeClassByName Include="ThisAssembly">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\nanoFramework.Device.Can.Core\nanoFramework.Device.Can.Core.nfproj"  Condition=" '$(Configuration)' != 'GenerateStubs' "/>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(Configuration)' == 'GenerateStubs' ">
+    <Compile Include="..\nanoFramework.Device.Can.Core\CanController.cs" />
+    <Compile Include="..\nanoFramework.Device.Can.Core\CanMessage.cs" />
+    <Compile Include="..\nanoFramework.Device.Can.Core\CanMessageFrameType.cs" />
+    <Compile Include="..\nanoFramework.Device.Can.Core\CanSettings.cs" />
+    <Compile Include="..\nanoFramework.Device.Can.Core\CanEvent.cs" />
+    <Compile Include="..\nanoFramework.Device.Can.Core\CanMessageIdType.cs" />
+    <Compile Include="..\nanoFramework.Device.Can.Core\CanMessageReceivedEventArgs.cs" />
+    <Compile Include="..\nanoFramework.Device.Can.Core\CanControllerEventListener.cs" />
+    <Compile Include="..\nanoFramework.Device.Can.Core\CanMessageEvent.cs" />
+  </ItemGroup>
+</Project>

--- a/nanoFramework.Device.Can.Esp32/nanoFramework.Device.Can.Esp32.nfproj
+++ b/nanoFramework.Device.Can.Esp32/nanoFramework.Device.Can.Esp32.nfproj
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Nerdbank.GitVersioning.3.7.115\build\Nerdbank.GitVersioning.props" Condition="Exists('..\packages\Nerdbank.GitVersioning.3.7.115\build\Nerdbank.GitVersioning.props')" />
+  <Import Project="nanoFramework.Device.Can.Esp32.native.props" />
   <PropertyGroup Label="Globals">
     <NanoFrameworkProjectSystemPath>$(MSBuildExtensionsPath)\nanoFramework\v1.0\</NanoFrameworkProjectSystemPath>
   </PropertyGroup>
@@ -16,7 +17,6 @@
     <RootNamespace>nanoFramework.Device.Can</RootNamespace>
     <AssemblyName>nanoFramework.Device.Can.Esp32</AssemblyName>
     <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
-    <NF_IsCoreLibrary>True</NF_IsCoreLibrary>
     <DocumentationFile>bin\$(Configuration)\nanoFramework.Device.Can.Esp32.xml</DocumentationFile>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <RestoreLockedMode Condition="'$(TF_BUILD)' == 'True' or '$(ContinuousIntegrationBuild)' == 'True'">true</RestoreLockedMode>
@@ -31,16 +31,6 @@
   <PropertyGroup>
     <DelaySign>false</DelaySign>
   </PropertyGroup>
-  <PropertyGroup Label="nanoFramework">
-    <NF_GenerateStubsDirectory>bin\$(Configuration)\Stubs</NF_GenerateStubsDirectory>
-    <NF_GenerateSkeletonProjectName>nf_device_can_esp32_native</NF_GenerateSkeletonProjectName>
-    <Name>nanoFramework.Device.Can.Esp32</Name>
-  </PropertyGroup>
-  <ItemGroup>
-    <NFMDP_PE_ExcludeClassByName Include="ThisAssembly">
-      <InProject>false</InProject>
-    </NFMDP_PE_ExcludeClassByName>
-  </ItemGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
     <None Include="key.snk" />
@@ -53,9 +43,12 @@
     <Reference Include="mscorlib, Version=1.16.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\packages\nanoFramework.CoreLibrary.1.16.11\lib\mscorlib.dll</HintPath>
     </Reference>
+    <Reference Include="nanoFramework.Runtime.Events, Version=1.11.29.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.Runtime.Events.1.11.29\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\nanoFramework.Device.Can.Core\nanoFramework.Device.Can.Core.nfproj" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets')" />
   <ProjectExtensions>

--- a/nanoFramework.Device.Can.Esp32/packages.config
+++ b/nanoFramework.Device.Can.Esp32/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="nanoFramework.CoreLibrary" version="1.16.11" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Runtime.Events" version="1.11.29" targetFramework="netnano1.0" />
   <package id="Nerdbank.GitVersioning" version="3.7.115" developmentDependency="true" targetFramework="netnano1.0" />
 </packages>

--- a/nanoFramework.Device.Can.Esp32/packages.lock.json
+++ b/nanoFramework.Device.Can.Esp32/packages.lock.json
@@ -8,6 +8,12 @@
         "resolved": "1.16.11",
         "contentHash": "2XW+Zn0lQ+lOcxDbB1l2ga2rNoj9Jv2IeJwXE4ka1r+swmxn5N/otlMJVEXJgK8trUeD/E8T7+J7dXjU8UReHw=="
       },
+      "nanoFramework.Runtime.Events": {
+        "type": "Direct",
+        "requested": "[1.11.29, 1.11.29]",
+        "resolved": "1.11.29",
+        "contentHash": "y3Y0SNfr1afMor4xrsiB1ETldjKvmnzBTcEH5gizFFXw3RNBB/N8npWqkCJn4HZS0TEENlH2vVrib3bWYMx5+Q=="
+      },
       "Nerdbank.GitVersioning": {
         "type": "Direct",
         "requested": "[3.7.115, 3.7.115]",

--- a/nanoFramework.Device.Can.Mcp2515/nanoFramework.Device.Can.Mcp2515.nfproj
+++ b/nanoFramework.Device.Can.Mcp2515/nanoFramework.Device.Can.Mcp2515.nfproj
@@ -51,6 +51,9 @@
   <ItemGroup>
     <ProjectReference Include="..\nanoFramework.Device.Can.Core\nanoFramework.Device.Can.Core.nfproj" />
   </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets')" />
   <ProjectExtensions>
     <ProjectCapabilities>

--- a/nanoFramework.Device.Can.sln
+++ b/nanoFramework.Device.Can.sln
@@ -12,7 +12,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Packages and stubs", "Packa
 		nanoFramework.Device.Can.Stm32.nuspec = nanoFramework.Device.Can.Stm32.nuspec
 		NuGet.Config = NuGet.Config
 		README.md = README.md
-		Stub-generation.md = Stub-generation.md
+		Nuspec and stub-generation.md = Nuspec and stub-generation.md
 		version.json = version.json
 	EndProjectSection
 EndProject
@@ -32,16 +32,15 @@ Global
 		{99CA76E4-D76F-42C9-9E62-49C2F499AA02}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{99CA76E4-D76F-42C9-9E62-49C2F499AA02}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{99CA76E4-D76F-42C9-9E62-49C2F499AA02}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
-		{99CA76E4-D76F-42C9-9E62-49C2F499AA02}.GenerateStubs|Any CPU.ActiveCfg = GenerateStubs|Any CPU
-		{99CA76E4-D76F-42C9-9E62-49C2F499AA02}.GenerateStubs|Any CPU.Build.0 = GenerateStubs|Any CPU
+		{99CA76E4-D76F-42C9-9E62-49C2F499AA02}.GenerateStubs|Any CPU.ActiveCfg = Debug|Any CPU
 		{99CA76E4-D76F-42C9-9E62-49C2F499AA02}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{99CA76E4-D76F-42C9-9E62-49C2F499AA02}.Release|Any CPU.Build.0 = Release|Any CPU
 		{99CA76E4-D76F-42C9-9E62-49C2F499AA02}.Release|Any CPU.Deploy.0 = Release|Any CPU
 		{7CE9A616-F4A4-43EA-B067-526155C823AC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7CE9A616-F4A4-43EA-B067-526155C823AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7CE9A616-F4A4-43EA-B067-526155C823AC}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
-		{7CE9A616-F4A4-43EA-B067-526155C823AC}.GenerateStubs|Any CPU.ActiveCfg = Debug|Any CPU
-		{7CE9A616-F4A4-43EA-B067-526155C823AC}.GenerateStubs|Any CPU.Build.0 = Debug|Any CPU
+		{7CE9A616-F4A4-43EA-B067-526155C823AC}.GenerateStubs|Any CPU.ActiveCfg = GenerateStubs|Any CPU
+		{7CE9A616-F4A4-43EA-B067-526155C823AC}.GenerateStubs|Any CPU.Build.0 = GenerateStubs|Any CPU
 		{7CE9A616-F4A4-43EA-B067-526155C823AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7CE9A616-F4A4-43EA-B067-526155C823AC}.Release|Any CPU.Build.0 = Release|Any CPU
 		{7CE9A616-F4A4-43EA-B067-526155C823AC}.Release|Any CPU.Deploy.0 = Release|Any CPU
@@ -49,7 +48,6 @@ Global
 		{695177A1-93CE-4AC4-88A2-EEFDDF327D0F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{695177A1-93CE-4AC4-88A2-EEFDDF327D0F}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
 		{695177A1-93CE-4AC4-88A2-EEFDDF327D0F}.GenerateStubs|Any CPU.ActiveCfg = Debug|Any CPU
-		{695177A1-93CE-4AC4-88A2-EEFDDF327D0F}.GenerateStubs|Any CPU.Build.0 = Debug|Any CPU
 		{695177A1-93CE-4AC4-88A2-EEFDDF327D0F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{695177A1-93CE-4AC4-88A2-EEFDDF327D0F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{695177A1-93CE-4AC4-88A2-EEFDDF327D0F}.Release|Any CPU.Deploy.0 = Release|Any CPU

--- a/spelling_exclusion.dic
+++ b/spelling_exclusion.dic
@@ -1,1 +1,3 @@
 nano
+nfproj
+Nuspec


### PR DESCRIPTION
## Description

This PR is about generating stubs for native code, not about the .NET code. If this is the correct approach, the PR can be merged into the *can_vnext* branch.

- `Nuspec and stub-generation.md` description is updated with the approach in this PR.
- Added **GenerateStubs** to solution, currently only for `nanoFramework.Device.Can.Esp32` as demonstrator.
- Added `nanoFramework.Device.Can.Esp32.native.props` to `nanoFramework.Device.Can.Esp32` with all relevant project settings, including the code files from `nanoFramework.Device.Can.Core` that should be included in the stub generation
- Some parts of the code of `nanoFramework.Device.Can.Core` can be hidden from the stub generation. As an example, the code referring to `CanControllerManager` is excluded from `CanController.cs`.

## Motivation and Context

See Discord discussion [here](https://discord.com/channels/478725473862549535/1326492411131723798/1326492411131723798).

## How Has This Been Tested?

- If *GenerateStubs* is selected VS2022 and 'nanoFramework.Device.Can.Esp32' is built, the stubs are generated for the included code files from the Core library and the resulting dll has code for the `nanoFramework.Device.Can` namespace.
- 
- If *Debug* is selected VS2022 and 'nanoFramework.Device.Can.Esp32' is built, the resulting dll has no code for the `nanoFramework.Device.Can` namespace as expected.

## Types of changes
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
